### PR TITLE
Reduce horizontal padding for small tabs

### DIFF
--- a/Afterglow-blue.sublime-theme
+++ b/Afterglow-blue.sublime-theme
@@ -64,6 +64,12 @@
         "content_margin": [22, 0, 22, 0]
     },
     {
+        //  - Tab close state small
+        "class": "tab_control",
+        "settings": ["show_tab_close_buttons", "tabs_small"],
+        "content_margin": [8, 0, 5, 0]
+    },
+    {
         //  - Hover tab state
         "class": "tab_control",
         "attributes": ["hover"],

--- a/Afterglow-green.sublime-theme
+++ b/Afterglow-green.sublime-theme
@@ -64,6 +64,12 @@
         "content_margin": [22, 0, 22, 0]
     },
     {
+        //  - Tab close state small
+        "class": "tab_control",
+        "settings": ["show_tab_close_buttons", "tabs_small"],
+        "content_margin": [8, 0, 5, 0]
+    },
+    {
         //  - Hover tab state
         "class": "tab_control",
         "attributes": ["hover"],

--- a/Afterglow-magenta.sublime-theme
+++ b/Afterglow-magenta.sublime-theme
@@ -64,6 +64,12 @@
         "content_margin": [22, 0, 22, 0]
     },
     {
+        //  - Tab close state small
+        "class": "tab_control",
+        "settings": ["show_tab_close_buttons", "tabs_small"],
+        "content_margin": [8, 0, 5, 0]
+    },
+    {
         //  - Hover tab state
         "class": "tab_control",
         "attributes": ["hover"],

--- a/Afterglow-orange.sublime-theme
+++ b/Afterglow-orange.sublime-theme
@@ -64,6 +64,12 @@
         "content_margin": [22, 0, 22, 0]
     },
     {
+        //  - Tab close state small
+        "class": "tab_control",
+        "settings": ["show_tab_close_buttons", "tabs_small"],
+        "content_margin": [8, 0, 5, 0]
+    },
+    {
         //  - Hover tab state
         "class": "tab_control",
         "attributes": ["hover"],

--- a/Afterglow.sublime-theme
+++ b/Afterglow.sublime-theme
@@ -64,6 +64,12 @@
         "content_margin": [22, 0, 22, 0]
     },
     {
+        //  - Tab close state small
+        "class": "tab_control",
+        "settings": ["show_tab_close_buttons", "tabs_small"],
+        "content_margin": [8, 0, 5, 0]
+    },
+    {
         //  - Hover tab state
         "class": "tab_control",
         "attributes": ["hover"],


### PR DESCRIPTION
The horizontal padding is too much for small tabs and the close button is not in the expected position.
In addition, the padding becomes a problem when you have a lot of tabs open.

`[8,0,5,0]` seems to work well, as there's a 2-3px padding on the right coming from somewhere else which I couldn't get rid of
