### PR TITLE
Add support for GitGutter and Critic Markup

### DIFF
--- a/Afterglow-markdown.tmTheme
+++ b/Afterglow-markdown.tmTheme
@@ -669,6 +669,63 @@
                 <string>#E78400</string>
             </dict>
         </dict>
+
+<!-- GitGutter -->
+        <dict>
+          <key>name</key>
+          <string>GitGutter deleted</string>
+          <key>scope</key>
+          <string>markup.deleted.git_gutter</string>
+          <key>settings</key>
+          <dict>
+            <key>foreground</key>
+            <string>#F92672</string>
+          </dict>
+        </dict>
+        <dict>
+          <key>name</key>
+          <string>GitGutter inserted</string>
+          <key>scope</key>
+          <string>markup.inserted.git_gutter</string>
+          <key>settings</key>
+          <dict>
+            <key>foreground</key>
+            <string>#A6E22E</string>
+          </dict>
+        </dict>
+        <dict>
+          <key>name</key>
+          <string>GitGutter changed</string>
+          <key>scope</key>
+          <string>markup.changed.git_gutter</string>
+          <key>settings</key>
+          <dict>
+            <key>foreground</key>
+            <string>#967EFB</string>
+          </dict>
+        </dict>
+        <dict>
+          <key>name</key>
+          <string>GitGutter ignored</string>
+          <key>scope</key>
+          <string>markup.ignored.git_gutter</string>
+          <key>settings</key>
+          <dict>
+            <key>foreground</key>
+            <string>#565656</string>
+          </dict>
+        </dict>
+        <dict>
+          <key>name</key>
+          <string>GitGutter untracked</string>
+          <key>scope</key>
+          <string>markup.untracked.git_gutter</string>
+          <key>settings</key>
+          <dict>
+            <key>foreground</key>
+            <string>#565656</string>
+          </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
I love using Afterglow but I was frustrated with the lack of GitGutter colours and Critic Markup so I added them in. Because the styles aren't detrimental to others I thought it should be part of the main package. Works especially well with the proposed changes by @felixhao28 to Markdown Editing (waiting for the PR to be accepted there). Screenshot to see the outcome.

![critic markup and gitgutter](https://cloud.githubusercontent.com/assets/7970809/4593398/aab4dd48-5085-11e4-820a-fabdea84227b.png)
