### PR TITLE
Remove invalid trailing comma in messages.json

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -8,5 +8,5 @@
   "1.2.5": "messages/1.2.5.txt",
   "1.2.6": "messages/1.2.6.txt",
   "1.2.7": "messages/1.2.7.txt",
-  "1.2.8": "messages/1.2.8.txt",
+  "1.2.8": "messages/1.2.8.txt"
 }


### PR DESCRIPTION
Trailing comma breaks installation (for me). It does not validate on jsonlint.com, either.