### PR TITLE
Add fallback for Docker files to text.plain

### DIFF
--- a/Prefs/Langs/Dockerfile.tmLanguage
+++ b/Prefs/Langs/Dockerfile.tmLanguage
@@ -17,6 +17,6 @@
     </dict>
   </array>
   <key>scopeName</key>
-  <string>source.dockerfile</string>
+  <string>text.plain, source.dockerfile</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR should fix #73 and #67, but should be tested carefully. 

The problems caused by forced setting `source.dockerfile` scope upon opening `Dockerfile`, while valid `source.dockerfile` package were missing. Now we could fallback to simple `text.plain`. Icon still be displayed in the sidebar, files could be opened, but syntax highlighting will absent.
