### PR TITLE
Fix for sidebar_no_icon fix #86

### DIFF
--- a/Afterglow-blue.sublime-theme
+++ b/Afterglow-blue.sublime-theme
@@ -695,11 +695,6 @@
     },
     {
         "class": "icon_file_type",
-        "settings": ["sidebar_no_icon"],
-        "content_margin": [8, 8]
-    },
-    {
-        "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
         "layer0.opacity": 1.0
     },
@@ -707,6 +702,11 @@
         "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
         "layer0.opacity": 1.0
+    },
+    {
+        "class": "icon_file_type",
+        "settings": ["sidebar_no_icon"],
+        "layer0.opacity": 0.0,
     },
 
 //

--- a/Afterglow-green.sublime-theme
+++ b/Afterglow-green.sublime-theme
@@ -695,11 +695,6 @@
     },
     {
         "class": "icon_file_type",
-        "settings": ["sidebar_no_icon"],
-        "content_margin": [8, 8]
-    },
-    {
-        "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
         "layer0.opacity": 1.0
     },
@@ -707,6 +702,11 @@
         "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
         "layer0.opacity": 1.0
+    },
+    {
+        "class": "icon_file_type",
+        "settings": ["sidebar_no_icon"],
+        "layer0.opacity": 0.0,
     },
 
 //

--- a/Afterglow-magenta.sublime-theme
+++ b/Afterglow-magenta.sublime-theme
@@ -696,11 +696,6 @@
     },
     {
         "class": "icon_file_type",
-        "settings": ["sidebar_no_icon"],
-        "content_margin": [8, 8]
-    },
-    {
-        "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
         "layer0.opacity": 1.0
     },
@@ -708,6 +703,11 @@
         "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
         "layer0.opacity": 1.0
+    },
+    {
+        "class": "icon_file_type",
+        "settings": ["sidebar_no_icon"],
+        "layer0.opacity": 0.0,
     },
 
 //

--- a/Afterglow-orange.sublime-theme
+++ b/Afterglow-orange.sublime-theme
@@ -695,11 +695,6 @@
     },
     {
         "class": "icon_file_type",
-        "settings": ["sidebar_no_icon"],
-        "content_margin": [8, 8]
-    },
-    {
-        "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
         "layer0.opacity": 1.0
     },
@@ -707,6 +702,11 @@
         "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
         "layer0.opacity": 1.0
+    },
+    {
+        "class": "icon_file_type",
+        "settings": ["sidebar_no_icon"],
+        "layer0.opacity": 0.0,
     },
 
 //

--- a/Afterglow.sublime-theme
+++ b/Afterglow.sublime-theme
@@ -695,11 +695,6 @@
     },
     {
         "class": "icon_file_type",
-        "settings": ["sidebar_no_icon"],
-        "content_margin": [8, 8]
-    },
-    {
-        "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
         "layer0.opacity": 1.0
     },
@@ -707,6 +702,16 @@
         "class": "icon_file_type",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
         "layer0.opacity": 1.0
+    },
+    //This could easily become the following:
+    // - sidebar_no_icon
+    // - sidebar_no_icon_hover
+    // - sidebar_no_icon_selected
+    //Doing the quick way because this is currently a bug
+    {
+        "class": "icon_file_type",
+        "settings": ["sidebar_no_icon"],
+        "layer0.opacity": 0.0,
     },
 
 //


### PR DESCRIPTION
This is a fix for issue #86.  Instead of doing the margin offset as you were before, we need to adjust the opacity.  This should be the fix needed across all colored themes as well.  Beyond this, something I noted in the comments:  This could easily expand to more settings to show the icon on hover or on selected.