### PR TITLE
fix Gulp and Grunt commenting and snippets, issue #72

### DIFF
--- a/Prefs/Langs/Gruntfile Coffee.tmLanguage
+++ b/Prefs/Langs/Gruntfile Coffee.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.coffee.gruntfile</string>
+	<string>source.coffee, source.coffee.gruntfile</string>
 </dict>
 </plist>

--- a/Prefs/Langs/Gruntfile Coffee.tmLanguage
+++ b/Prefs/Langs/Gruntfile Coffee.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.coffee, source.gruntfile.coffee</string>
+	<string>source.coffee.gruntfile</string>
 </dict>
 </plist>

--- a/Prefs/Langs/Gruntfile JS.tmLanguage
+++ b/Prefs/Langs/Gruntfile JS.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.js.gruntfile</string>
+	<string>source.js, source.js.gruntfile</string>
 </dict>
 </plist>

--- a/Prefs/Langs/Gruntfile JS.tmLanguage
+++ b/Prefs/Langs/Gruntfile JS.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.js, source.gruntfile.js</string>
+	<string>source.js.gruntfile</string>
 </dict>
 </plist>

--- a/Prefs/Langs/Gulpfile Coffee.tmLanguage
+++ b/Prefs/Langs/Gulpfile Coffee.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.coffee.gulpfile</string>
+	<string>source.coffee, source.coffee.gulpfile</string>
 </dict>
 </plist>

--- a/Prefs/Langs/Gulpfile Coffee.tmLanguage
+++ b/Prefs/Langs/Gulpfile Coffee.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.coffee, source.gulpfile.coffee</string>
+	<string>source.coffee.gulpfile</string>
 </dict>
 </plist>

--- a/Prefs/Langs/Gulpfile JS.tmLanguage
+++ b/Prefs/Langs/Gulpfile JS.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.js.gulpfile</string>
+	<string>source.js, source.js.gulpfile</string>
 </dict>
 </plist>

--- a/Prefs/Langs/Gulpfile JS.tmLanguage
+++ b/Prefs/Langs/Gulpfile JS.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.js, source.gulpfile.js</string>
+	<string>source.js.gulpfile</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes issue #72. Changed the scopeName for the Gulp and Grunt syntax definitions so they inherit the JavaScript/CoffeeScript scope. This allows snippets and commenting to work like it would in a JS file.
