### PR TITLE
Add support for gulpfile.babel.js

### DIFF
--- a/Prefs/Langs/Gulpfile Babel JS.tmLanguage
+++ b/Prefs/Langs/Gulpfile Babel JS.tmLanguage
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Gulpfile Babel JS</string>
+	<key>fileTypes</key>
+	<array>
+		<string>gulpfile.babel.js</string>
+	</array>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>include</key>
+			<string>source.js</string>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>source.js, source.gulpfile.babel.js</string>
+</dict>
+</plist>


### PR DESCRIPTION
As Gulp supports ES2015 and Babel, Afterglow should support `gulpfile.babel.js`.
