### PR TITLE
Fix tabs margin for colored themes

### DIFF
--- a/Afterglow-blue.sublime-theme
+++ b/Afterglow-blue.sublime-theme
@@ -38,7 +38,7 @@
     //  ------------------------------------------------------
     {
         "class": "tab_control",
-        "content_margin": [0, 0, 0, 0],
+        "content_margin": [22, 0, 22, 0],
         "max_margin_trim": 0,
         "hit_test_level": 0,
 

--- a/Afterglow-green.sublime-theme
+++ b/Afterglow-green.sublime-theme
@@ -38,7 +38,7 @@
     //  ------------------------------------------------------
     {
         "class": "tab_control",
-        "content_margin": [0, 0, 0, 0],
+        "content_margin": [22, 0, 22, 0],
         "max_margin_trim": 0,
         "hit_test_level": 0,
 

--- a/Afterglow-magenta.sublime-theme
+++ b/Afterglow-magenta.sublime-theme
@@ -38,7 +38,7 @@
     //  ------------------------------------------------------
     {
         "class": "tab_control",
-        "content_margin": [0, 0, 0, 0],
+        "content_margin": [22, 0, 22, 0],
         "max_margin_trim": 0,
         "hit_test_level": 0,
 

--- a/Afterglow-orange.sublime-theme
+++ b/Afterglow-orange.sublime-theme
@@ -38,7 +38,7 @@
     //  ------------------------------------------------------
     {
         "class": "tab_control",
-        "content_margin": [0, 0, 0, 0],
+        "content_margin": [22, 0, 22, 0],
         "max_margin_trim": 0,
         "hit_test_level": 0,
 


### PR DESCRIPTION
Tabs didn't had margins for colored theme variants.

Colored example:
![image](https://user-images.githubusercontent.com/38900226/120122858-e3b27f00-c181-11eb-9d9e-a6416502824f.png)

Default:
![image](https://user-images.githubusercontent.com/38900226/120122872-f4fb8b80-c181-11eb-8373-ff381c1306ef.png)

This PR applies the same margin as the `default` one to the other UI themes.